### PR TITLE
MySQL 8 support

### DIFF
--- a/src/testing/mysqld.py
+++ b/src/testing/mysqld.py
@@ -49,7 +49,10 @@ class Mysqld(Database):
 
         self.mysql_install_db = self.settings.get('mysql_install_db')
         if self.mysql_install_db is None:
-            self.mysql_install_db = find_program('mysql_install_db', ['bin', 'scripts'])
+            try:
+                self.mysql_install_db = find_program('mysql_install_db', ['bin', 'scripts'])
+            except RuntimeError:
+                pass
 
         self.mysqld = self.settings.get('mysqld')
         if self.mysqld is None:
@@ -119,15 +122,15 @@ class Mysqld(Database):
             args = ["--defaults-file=%s/etc/my.cnf" % self.base_dir,
                     "--datadir=%s" % self.my_cnf['datadir']]
 
-            mysql_base_dir = self.mysql_install_db
+            mysql_base_dir = self.mysqld
             if os.path.islink(mysql_base_dir):
                 link = os.readlink(mysql_base_dir)
                 mysql_base_dir = os.path.join(os.path.dirname(mysql_base_dir),
                                               link)
                 mysql_base_dir = os.path.normpath(mysql_base_dir)
 
-            if re.search('[^/]+/mysql_install_db$', mysql_base_dir):
-                args.append("--basedir=%s" % re.sub('[^/]+/mysql_install_db$', '', mysql_base_dir))
+            if re.search('[^/]+/mysqld$', mysql_base_dir):
+                args.append("--basedir=%s" % re.sub('[^/]+/mysqld$', '', mysql_base_dir))
 
             try:
                 mysqld_args = [self.mysqld] + args + ["--initialize-insecure"]

--- a/tests/test_mysqld.py
+++ b/tests/test_mysqld.py
@@ -169,7 +169,8 @@ class TestMysqld(unittest.TestCase):
                 cursor = conn.cursor()
                 cursor.execute("CREATE TABLE hello(id int, value varchar(256))")
                 cursor.execute("INSERT INTO hello values(1, 'hello'), (2, 'ciao')")
-                cursor.execute("SET PASSWORD FOR 'root'@'localhost' = PASSWORD('secret'); FLUSH PRIVILEGES;")
+                cursor.execute("ALTER USER 'root'@'localhost' IDENTIFIED BY 'secret'")
+                cursor.execute("FLUSH PRIVILEGES")
                 conn.commit()
 
             # create another database from first one

--- a/tests/test_mysqld.py
+++ b/tests/test_mysqld.py
@@ -32,7 +32,7 @@ class TestMysqld(unittest.TestCase):
             # connect to mysql (w/ pymysql)
             conn = pymysql.connect(**mysqld.dsn())
             self.assertIsNotNone(conn)
-            self.assertRegexpMatches(mysqld.read_bootlog(), 'ready for connections')
+            self.assertRegex(mysqld.read_bootlog(), 'ready for connections')
 
             # connect to mysql (w/ sqlalchemy)
             engine = sqlalchemy.create_engine(mysqld.url())


### PR DESCRIPTION
Fixes #7 . Switches to shrugging when `mysql_install_db` is missing, and uses `mysqld` to find the base directory. Also updated the syntax in a test, since mysql 8 changed the way that setting passwords works, and handled a deprecation warning in py3.7 while I was in there.

Haven't tested against mysql 5.x but did test against my local mysql 8 and seems to be working well!